### PR TITLE
Changed log_f to be configuration for winston file transport

### DIFF
--- a/examples/log-to-file.js
+++ b/examples/log-to-file.js
@@ -1,0 +1,41 @@
+var straw = require('../lib/straw.js');
+
+var opts = {
+  nodes_dir: __dirname + '/nodes',
+  redis: {
+    host: '127.0.0.1',
+    port: 6379,
+    prefix: 'straw-example'
+  }};
+
+// This is the configuration for winston File transport:
+opts.log_f = {
+	filename: 'logfile.log'
+};
+
+var topo = straw.create(opts);
+
+topo.add([{
+  id: 'ping',
+  node: 'ping',
+  output: 'ping-out' 
+}, {
+  id: 'count',
+  node: 'count',
+  input: 'ping-out',
+  output: 'count-out' 
+},{
+  id: 'print',
+  node: 'print',
+  input: 'count-out'
+}], function(){
+  topo.start({
+    purge: true
+  });
+});
+
+process.on( 'SIGINT', function() {
+  topo.destroy(function(){
+    console.log( 'Finished.' );
+  });
+});

--- a/lib/topology.js
+++ b/lib/topology.js
@@ -502,7 +502,7 @@ var create = function(){
 
     var transports = [];
     if(opts.hasOwnProperty('log_f')){
-      transports.push(new (winston.transports.File)({ filename: 'somefile.log' }));
+      transports.push(new (winston.transports.File)(opts.log_f));
     } else {
       transports.push(new (winston.transports.Console)(opts.logging));
     }


### PR DESCRIPTION
The winston file transport (logging to file) was hardcoded to write into 'somefile.log' when log_f property was set. Changed log_f to be options for the file transport instead for configurability.
