### PR TITLE
Fixed issue regarding node stop method not called in the correct context

### DIFF
--- a/lib/run.js
+++ b/lib/run.js
@@ -177,7 +177,7 @@ function Run() {
     if ( data === 'QUIT' ) {
       process.send('QUITTING');
       async.parallel([
-        node.stop,
+        node.stop.bind(node),
         self.stop
       ], function(){
         self.stoppedCallback = null;


### PR DESCRIPTION
Fixed issue regarding the node stop method not being called with the correct context when the topology destroy method is called.